### PR TITLE
Adds support for file operations using the shadow file system.

### DIFF
--- a/src/Our.Umbraco.StorageProviders.AWSS3/IO/AWSS3FileSystem.cs
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/IO/AWSS3FileSystem.cs
@@ -256,29 +256,23 @@ namespace Our.Umbraco.StorageProviders.AWSS3.IO
             var request = new GetObjectMetadataRequest
             {
                 BucketName = _bucketName,
-                Key = ResolveBucketPath(path),
+                Key = ResolveBucketPath(path)
             };
 
             try
             {
-                var response = Execute(client => client.GetObjectMetadataAsync(request)).Result;
+                var response = Execute(client => client.GetObjectMetadataAsync(request)).GetAwaiter().GetResult();
                 return true;
             }
             catch (FileNotFoundException)
             {
                 return false;
             }
-            catch (AggregateException ex)
+            catch (AmazonS3Exception ex)
             {
-                foreach (var innerEx in ex.InnerExceptions)
+                if (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
-                    if (innerEx is AmazonS3Exception amazonS3Exception)
-                    {
-                        if (amazonS3Exception.StatusCode == System.Net.HttpStatusCode.NotFound)
-                        {
-                            return false;
-                        }
-                    }
+                    return false;
                 }
 
                 throw;

--- a/src/Our.Umbraco.StorageProviders.AWSS3/IO/AWSS3FileSystem.cs
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/IO/AWSS3FileSystem.cs
@@ -1,16 +1,13 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Logging;
+using Our.Umbraco.StorageProviders.AWSS3.Services;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Amazon.S3;
-using Amazon.S3.Model;
-using Microsoft.AspNetCore.StaticFiles;
 using Umbraco.Cms.Core.Hosting;
-using Umbraco.Cms.Core.IO;
-using Our.Umbraco.StorageProviders.AWSS3.Services;
-using Microsoft.Extensions.Logging;
 
 namespace Our.Umbraco.StorageProviders.AWSS3.IO
 {
@@ -30,7 +27,7 @@ namespace Our.Umbraco.StorageProviders.AWSS3.IO
         protected const string Delimiter = "/";
         protected const int BatchSize = 1000;
 
-        public bool CanAddPhysical => throw new NotImplementedException();
+        public bool CanAddPhysical => false;
 
         /// <summary>
         ///     Creates a new instance of <see cref="AWSS3FileSystem" />.
@@ -149,22 +146,45 @@ namespace Our.Umbraco.StorageProviders.AWSS3.IO
 
         public void AddFile(string path, Stream stream, bool overrideIfExists)
         {
+            if (!overrideIfExists && FileExists(path))
+            {
+                throw new InvalidOperationException($"A file at path '{path}' already exists");
+            }
+
             using (var memoryStream = new MemoryStream())
             {
                 stream.CopyTo(memoryStream);
-                var request = new PutObjectRequest
-                {
-                    BucketName = _bucketName,
-                    Key = ResolveBucketPath(path),
-                    CannedACL = _cannedACL,
-                    ContentType = _mimeTypeResolver.Resolve(path),
-                    InputStream = memoryStream,
-                    ServerSideEncryptionMethod = _serverSideEncryptionMethod
-                };
-
-                var response = Execute(client => client.PutObjectAsync(request)).Result;
-                _logger.LogInformation(string.Format("Object {0} Created, Id:{1}, Hash:{2}", path, response.VersionId, response.ETag));
+                AddFileFromStream(path, memoryStream);
             }
+        }
+
+        public void AddFile(string path, string physicalPath, bool overrideIfExists = true, bool copy = false)
+        {
+            if (!overrideIfExists && FileExists(path))
+            {
+                throw new InvalidOperationException($"A file at path '{path}' already exists");
+            }
+
+            using (var fileStream = new FileStream(physicalPath, FileMode.Open))
+            {
+                AddFileFromStream(path, fileStream);
+            }
+        }
+
+        private void AddFileFromStream(string path, Stream inputStream)
+        {
+            var request = new PutObjectRequest
+            {
+                BucketName = _bucketName,
+                Key = ResolveBucketPath(path),
+                CannedACL = _cannedACL,
+                ContentType = _mimeTypeResolver.Resolve(path),
+                InputStream = inputStream,
+                ServerSideEncryptionMethod = _serverSideEncryptionMethod
+            };
+
+            var response = Execute(client => client.PutObjectAsync(request)).Result;
+            _logger.LogInformation(string.Format("Object {0} Created, Id:{1}, Hash:{2}", path, response.VersionId, response.ETag));
         }
 
         public IEnumerable<string> GetFiles(string path)
@@ -236,17 +256,32 @@ namespace Our.Umbraco.StorageProviders.AWSS3.IO
             var request = new GetObjectMetadataRequest
             {
                 BucketName = _bucketName,
-                Key = ResolveBucketPath(path)
+                Key = ResolveBucketPath(path),
             };
 
             try
             {
-                Execute(client => client.GetObjectMetadataAsync(request));
+                var response = Execute(client => client.GetObjectMetadataAsync(request)).Result;
                 return true;
             }
             catch (FileNotFoundException)
             {
                 return false;
+            }
+            catch (AggregateException ex)
+            {
+                foreach (var innerEx in ex.InnerExceptions)
+                {
+                    if (innerEx is AmazonS3Exception amazonS3Exception)
+                    {
+                        if (amazonS3Exception.StatusCode == System.Net.HttpStatusCode.NotFound)
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                throw;
             }
         }
 
@@ -335,11 +370,6 @@ namespace Our.Umbraco.StorageProviders.AWSS3.IO
             return response.ContentLength;
         }
 
-        public void AddFile(string path, string physicalPath, bool overrideIfExists = true, bool copy = false)
-        {
-            throw new NotImplementedException();
-        }
-        
         protected virtual T Execute<T>(Func<IAmazonS3, T> request)
         {
             try


### PR DESCRIPTION
Hi @adam-werner - recently I had [this issue](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/167) raised on the Umbraco Deploy issue tracker, from a customer using Deploy on-premise, and S3 for their media file system.  They were running into issues and after some investigation it looked to be because there are some methods in the file system implementation that either weren't implemented, or weren't returning the expected results.

For background, Deploy makes use of a CMS feature called the "shadow file system", which is used to create transactions around operations involving files.  I was able to create the following test code that illustrated the issue.  This works as expected with the local disk file system, or an Azure blob file system using [Umbraco.StorageProviders.AzureBlob](https://nuget.org/packages/Umbraco.StorageProviders.AzureBlob), but fails when using your S3 one.

```
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.IO;
using Umbraco.Cms.Core.PropertyEditors;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Strings;
using Umbraco.Cms.Web.Common.Controllers;
using IScopeProvider = Umbraco.Cms.Infrastructure.Scoping.IScopeProvider;

namespace TestS3.Controllers
{
    public class TestController : UmbracoApiController
    {
        private readonly IScopeProvider _scopeProvider;
        private readonly IMediaService _mediaService;
        private readonly IContentTypeBaseServiceProvider _contentTypeBaseServiceProvider;
        private readonly MediaFileManager _mediaFileManager;
        private readonly MediaUrlGeneratorCollection _mediaUrlGeneratorCollection;
        private readonly IShortStringHelper _shortStringHelper;

        public TestController(
            IScopeProvider scopeProvider,
            IMediaService mediaService,
            IContentTypeBaseServiceProvider contentTypeBaseServiceProvider,
            MediaFileManager mediaFileManager,
            MediaUrlGeneratorCollection mediaUrlGeneratorCollection,
            IShortStringHelper shortStringHelper)
        {
            _scopeProvider = scopeProvider;
            _mediaService = mediaService;
            _contentTypeBaseServiceProvider = contentTypeBaseServiceProvider;
            _mediaFileManager = mediaFileManager;
            _mediaUrlGeneratorCollection = mediaUrlGeneratorCollection;
            _shortStringHelper = shortStringHelper;
        }

        public IActionResult CreateMedia()
        {
            using var scope = _scopeProvider.CreateScope(scopeFileSystems: true);
            using var stream = System.IO.File.OpenRead("c:\\temp\\test-image.jpg");

            var mediaItem = _mediaService.CreateMedia("Test Image", -1, "Image");
            mediaItem.SetValue(
                _mediaFileManager,
                _mediaUrlGeneratorCollection,
                _shortStringHelper,
                _contentTypeBaseServiceProvider,
                Constants.Conventions.Media.File,
                "test.jpg",
                stream);

            _mediaService.Save(mediaItem);

            scope.Complete();
            return Ok("Done");
        }
    }
}
```

I've made it work with the changes provided in this PR.  Specifically I've:

- Amended the implementation of `FileExists`, which was returning `true` even when a file didn't exist, and triggering an exception from the CMS due to [this check](https://github.com/umbraco/Umbraco-CMS/blob/v10/dev/src/Umbraco.Core/IO/ShadowFileSystem.cs#L120).
- Provided implementations for a couple of methods that are called from the CMS here, that are currently throwing a `NotImplementedException`.

I hope that all makes sense and is useful.  I'm not that familiar with working with AWS so could be you'll see some things that can be improved, but at least with this in place I'm now able to use the shadow file system, and so hopefully this will sort out the issues with Umbraco Deploy, and any other package or code that relies on this transaction support.